### PR TITLE
Update curl_g2o

### DIFF
--- a/curl_g2o
+++ b/curl_g2o
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'net/http'
-require 'digest'
 require 'base64'
 require 'openssl'
 
@@ -71,7 +70,7 @@ def get(uri)
 end
 
 def sign_data(uri, data, options = {})
-  key = (options[:key] or 'some password')
+  key = (options[:password] or 'some password')
   digest = OpenSSL::HMAC.digest('md5', key, data + uri.path)
   Base64.encode64(digest).chomp
 end
@@ -86,7 +85,7 @@ end
 begin
     args = parse_token_from_arguments(ARGV)
     data = g2o_data_header(args[:token])
-    sign = sign_data(args[:url], data)
+    sign = sign_data(args[:url], data, args)
     exec_curl(data, sign, args[:args].join(' '))
 rescue ArgumentsError => e
     e.explain


### PR DESCRIPTION
The key is stored in the args hash under the tag ":password", not ":key". But it did not matter, because args was not passed to sign_data at all. So, all requests were generated with "some password" as the key (salt) completely ignoring, whatever the user may have specified on command-line.
Also, the digest package is not needed -- requiring openssl is enough.
