### PR TITLE
avoid changing the data header while parsing it

### DIFF
--- a/ngx_http_akamai_g2o_module.c
+++ b/ngx_http_akamai_g2o_module.c
@@ -249,7 +249,7 @@ void base64_signature_of_data(ngx_http_request_t *r, ngx_str_t data, ngx_str_t k
 
     HMAC_Init(&hmac, key.data, key.len, alcf->hash_function());
     HMAC_Update(&hmac, data.data, data.len);
-    HMAC_Update(&hmac, r->uri.data, r->uri.len);
+    HMAC_Update(&hmac, r->unparsed_uri.data, r->unparsed_uri.len);
     HMAC_Final(&hmac, md, &md_len);
 
     binary_to_base64(r, md, md_len, signature);


### PR DESCRIPTION
strtok adds \0's to the input string, this can cause problems if the request is later proxied to some remote server. the new implementation uses ngx_str_t's that have a length field and therefore no change to the original string is needed
