### PR TITLE
dynamic module build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Like any other nginx module use the `--add-module` option when configuring:
 
     ./configure --add-module=$PATH_TO_G2O_DIR
 or
+
     ./configure --add-dynamic-module=$PATH_TO_G2O_DIR
 if you want to use it as dynamic module (nginx >= 1.9.11 is required)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Controls access to content from Akamai edge servers, using the G2O headers: `X-A
 Like any other nginx module use the `--add-module` option when configuring:
 
     ./configure --add-module=$PATH_TO_G2O_DIR
+or
+    ./configure --add-dynamic-module=$PATH_TO_G2O_DIR
+if you want to use it as dynamic module (nginx >= 1.9.11 is required)
 
 It requires OpenSSL.
 

--- a/config
+++ b/config
@@ -1,5 +1,14 @@
 USE_MD5=YES
 USE_SHA1=YES
 ngx_addon_name=ngx_http_akamai_g2o_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_akamai_g2o_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_akamai_g2o_module.c"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_akamai_g2o_module
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_akamai_g2o_module.c"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_akamai_g2o_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_akamai_g2o_module.c"
+fi


### PR DESCRIPTION
Hi, starting from 1.9.11 nginx supports dynamic modules, the suggested config makes possible to build the module as dynamic one.
